### PR TITLE
Fix duplicate route constant and super admin task export

### DIFF
--- a/src/hooks/useSupabaseApi.ts
+++ b/src/hooks/useSupabaseApi.ts
@@ -242,7 +242,6 @@ export const useSupabaseApi = () => {
     getSessionAttendees,
     // Tasks
     createTask,
-    createSuperAdminTask,
     submitTask,
     gradeSubmission,
     getStudentTasks,
@@ -291,7 +290,7 @@ export const useSupabaseApi = () => {
     getStudentCurriculumProgress,
     generateParentReport,
     // Super Admin Task Management
-    createTask,
+    createSuperAdminTask,
     assignTaskToEmployees,
     assignTaskToStudents,
     getAllTasks,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,7 +18,6 @@ export const ROUTES = {
   TASKS: '/tasks',
   ABOUT: '/about',
   CONTACT: '/contact',
-  CONTACT: '/contact',
   AUTH: '/auth',
   PRIVACY: '/privacy',
   ADMIN: '/admin'


### PR DESCRIPTION
## Summary
- remove redundant CONTACT route entry in constants
- export correct `createSuperAdminTask` function without duplicating task API

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx eslint src/utils/constants.ts src/hooks/useSupabaseApi.ts` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_b_6895e3975cf4832cb2ba868464d2f7d7